### PR TITLE
Correctly check for existences of specific contentType

### DIFF
--- a/server/http.js
+++ b/server/http.js
@@ -90,7 +90,7 @@ function serveFile(filename,exists,request,response) {
     const contentType = path.extname(filename).slice(1);
 
     //Only serve specified file types
-    if(!this.config.contentType){
+    if(!this.config.contentType[contentType]){
         if(this.config.verbose){
             console.log(`${this.config.logID} 415 ###\n\n`);
         }


### PR DESCRIPTION
The test for contentTypes was just looking at the existence of the config hash, not checking for the existence of the current file extension in that hash.